### PR TITLE
Addressing Issue #35 by temporarily disabling users from editing profiles

### DIFF
--- a/src/members/single/member.js
+++ b/src/members/single/member.js
@@ -45,7 +45,7 @@ export class Member{
         if ( this._user === null ) {
             return false
         }
-        if ( this._user.Id === this._userCache.user.id || this._userCache.user.is_admin ) {
+        if (this._userCache.user.is_admin ) {
             return true
         }
         return false


### PR DESCRIPTION
Addressing Issue #35 by temporarily disabling users from editing their own stream info. Only Admins can now edit stream info in the dashboard.

* This is only a temporary remedy until the improper setting of user id is resolved
* Users weren't able to edit their own streams anyway because of a previous bug